### PR TITLE
Adds a more concrete path to gmd:referenceSystemInfo gmd:code

### DIFF
--- a/service/sch_19119.xml
+++ b/service/sch_19119.xml
@@ -638,7 +638,7 @@
 		<!-- INSPIRE interop SDS Referentiesysteem
 		-->
 		<!-- Referentiesysteem  -->
-		<sch:rule id="Referentiesysteem" etf_name="Referentiesysteem" context="//gmd:MD_Metadata/gmd:referenceSystemInfo/*">
+		<sch:rule id="Referentiesysteem" etf_name="Referentiesysteem" context="//gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
 			<!--  Ruimtelijk referentiesysteem  https://docs.geostandaarden.nl/md/mdprofiel-iso19119/#codereferentiesysteem -->
 			<!-- Oud commentaar: geen RS_Identifier meer, maar alleen een MD_Identifier -->
 			<!-- N.a.v. test 21 november 2018 beide toestaan -->

--- a/service/sch_19119_INS.xml
+++ b/service/sch_19119_INS.xml
@@ -719,7 +719,7 @@
 
 		<!-- INSPIRE interop SDS Referentiesysteem  -->
 		<!-- Referentiesysteem -->
-		<sch:rule id="Referentiesysteem" etf_name="Referentiesysteem" context="//gmd:MD_Metadata/gmd:referenceSystemInfo/*">
+		<sch:rule id="Referentiesysteem" etf_name="Referentiesysteem" context="//gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem">
 			<!--  Ruimtelijk referentiesysteem  https://docs.geostandaarden.nl/md/mdprofiel-iso19119/#codereferentiesysteem -->
 			<!-- Oud commentaar: geen RS_Identifier meer, maar alleen een MD_Identifier -->
 			<!-- N.a.v. test 21 november 2018 beide toestaan -->


### PR DESCRIPTION
Since the only possible child of `gmd:referenceSystemInfo` is `gmd:MD_ReferenceSystem`
add it to the context of the rule `id="Referentiesysteem"` as GeoNetwork has some
problems dealing with contexts ending in `*`.